### PR TITLE
Fix a crash in topic matching.

### DIFF
--- a/libnymea-mqtt/mqttserver.cpp
+++ b/libnymea-mqtt/mqttserver.cpp
@@ -628,6 +628,9 @@ bool MqttServerPrivate::matchTopic(const QString &topicFilter, const QString &to
         if (filterParts.at(i) == QStringLiteral("#")) {
             continue;
         }
+        if (topicParts.length() <= i) {
+            return false;
+        }
         if (topicParts.at(i) == filterParts.at(i)) {
             continue;
         }

--- a/tests/operation/test_operation.cpp
+++ b/tests/operation/test_operation.cpp
@@ -489,6 +489,7 @@ void OperationTests::testSubscriptionTopicMatching_data()
     rows.append({ "a//+/", "a///", "1" });
     rows.append({ "a//+/#", "a//b/c", "1" });
     rows.append({ "a//+/#", "a/b/c/d", "0" });
+    rows.append({ "a/b/c", "a/b", "0"});
 
     rows.append({ "$SYS/", "$SYS/", "0" });
     rows.append({ "#", "$SYS/", "0" });


### PR DESCRIPTION
Subscribing a client to a/b/c and publishing to a/b leads to a
crash, turns out it is a off-by-one calculation in topic matching code.